### PR TITLE
Add support for models that are contained by modules

### DIFF
--- a/lib/eav_hashes/activerecord_extension.rb
+++ b/lib/eav_hashes/activerecord_extension.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         # Create the association, the entry update hook, and a helper method to lazy-load the entries
         class_eval <<-END_EVAL
-          has_many :#{options[:entry_assoc_name]}
+          has_many :#{options[:entry_assoc_name]}, class_name: #{options[:entry_class_name]}, foreign_key: "#{options[:parent_assoc_name]}_id"
           after_save :save_#{hash_name}
           def #{hash_name}
             @#{hash_name} ||= ActiveRecord::EavHashes::EavHash.new(self, @@#{hash_name}_hash_options)

--- a/lib/generators/eav_migration/eav_migration.rb
+++ b/lib/generators/eav_migration/eav_migration.rb
@@ -15,7 +15,7 @@ class EavMigrationGenerator < ActiveRecord::Generators::Base
   end
 
   def migration_file_name
-    "create_#{name}_#{hash_name}".underscore
+    "create_" + table_name
   end
 
   def migration_name
@@ -23,10 +23,14 @@ class EavMigrationGenerator < ActiveRecord::Generators::Base
   end
 
   def table_name
-    custom_table_name || "#{name}_#{hash_name}".underscore
+    custom_table_name || "#{name}_#{hash_name}".underscore.gsub(/\//, '_')
   end
 
   def model_name
-   name
+    name
+  end
+
+  def model_association_name
+    model_name.underscore.gsub(/\//,'_')
   end
 end

--- a/lib/generators/eav_migration/templates/eav_migration.erb
+++ b/lib/generators/eav_migration/templates/eav_migration.erb
@@ -1,7 +1,7 @@
 class <%= migration_name %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|
-      t.references :<%= model_name.underscore %>, :null => false
+      t.references :<%= model_association_name %>, :null => false
       t.string :entry_key, :null => false
       t.text :value, :null => false
       t.integer :value_type, :null => false
@@ -10,7 +10,7 @@ class <%= migration_name %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= table_name %>, :<%= model_name.underscore %>_id
+    add_index :<%= table_name %>, :<%= model_association_name %>_id
     add_index :<%= table_name %>, :entry_key
   end
 end

--- a/spec/lib/generators/eav_migration_spec.rb
+++ b/spec/lib/generators/eav_migration_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe EavMigrationGenerator do
+  let(:top_level_model_generator) { EavMigrationGenerator.new(['TestModel', 'test_hash']) }
+  let(:one_module_generator) { EavMigrationGenerator.new(['Foo::TestModel', 'test_hash']) }
+  let(:multi_module_generator) { EavMigrationGenerator.new(['Foo::Bar::TestModel', 'test_hash']) }
+
+  describe "#model_association_name" do
+    context "when the model is at the top level" do
+      it "should underscore the model name" do
+        top_level_model_generator.model_association_name.should == "test_model"
+      end
+    end
+
+    context "when the model is namespaced by one module" do
+      it "should underscore the model name, replacing the slash with an underscore" do
+        one_module_generator.model_association_name.should == "foo_test_model"
+      end
+    end
+
+    context "when the model is namespaced by multiple modules" do
+      it "should underscore the model name, replacing the slashes with underscores" do
+        multi_module_generator.model_association_name.should == "foo_bar_test_model"
+      end
+    end
+  end
+
+  describe "#table_name" do
+    context "when the model is at the top level" do
+      it "should underscore the model name and append the hash name" do
+        top_level_model_generator.table_name.should == "test_model_test_hash"
+      end
+    end
+
+    context "when the model is namespaced by one module" do
+      it "should underscore the model name, replacing the slash with an underscore, and append the hash name" do
+        one_module_generator.table_name.should == "foo_test_model_test_hash"
+      end
+    end
+
+    context "when the model is namespaced by multiple modules" do
+      it "should underscore the model name, replacing the slashes with underscores, and append the hash name" do
+        multi_module_generator.table_name.should == "foo_bar_test_model_test_hash"
+      end
+    end
+  end
+
+  describe "#migration_file_name" do
+    context "when the model is at the top level" do
+      it "should return create_ followed by the table name" do
+        top_level_model_generator.migration_file_name.should == "create_test_model_test_hash"
+      end
+    end
+
+    context "when the model is namespaced by one or more modules" do
+      it "should return create_ followed by the table name, with module names included" do
+        multi_module_generator.migration_file_name.should == "create_foo_bar_test_model_test_hash"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a quick patch to allow eav_hashes to handle models that are contained within modules (e.g. Customer::Address). This is intended to support namespacing, not STI, though maybe it's a start toward STI support. I can't say for sure that I didn't break anything, since there are no tests (and unfortunately I didn't have time to write very many new tests), but it's been working well for me with both top-level and namespaced models.
