### PR TITLE
Calling destroy() leaves orphaned EAV entries

### DIFF
--- a/lib/eav_hashes/activerecord_extension.rb
+++ b/lib/eav_hashes/activerecord_extension.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         # Create the association, the entry update hook, and a helper method to lazy-load the entries
         class_eval <<-END_EVAL
-          has_many :#{options[:entry_assoc_name]}, class_name: #{options[:entry_class_name]}, foreign_key: "#{options[:parent_assoc_name]}_id"
+          has_many :#{options[:entry_assoc_name]}, class_name: #{options[:entry_class_name]}, foreign_key: "#{options[:parent_assoc_name]}_id", dependent: :delete_all
           after_save :save_#{hash_name}
           def #{hash_name}
             @#{hash_name} ||= ActiveRecord::EavHashes::EavHash.new(self, @@#{hash_name}_hash_options)

--- a/lib/eav_hashes/version.rb
+++ b/lib/eav_hashes/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module EavHashes
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end


### PR DESCRIPTION
Forgot to add `:dependent => :destroy_all` to the `has_many` associations. There should not longer be orphaned EavEntries when calling `destroy` on a parent model.
