### PR TITLE
Rails4 support

### DIFF
--- a/eav_hashes.gemspec
+++ b/eav_hashes.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
 #  s.add_dependency "rails", "~> 3.2.7"
-  s.add_dependency "rails", ">= 3.2.7", "<= 4"
+  s.add_dependency "rails", ">= 3.2.7"
   s.add_development_dependency "sqlite3"
 end

--- a/eav_hashes.gemspec
+++ b/eav_hashes.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*"] + %w(init.rb MIT-LICENSE Rakefile README.md)
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 3.2.7"
+#  s.add_dependency "rails", "~> 3.2.7"
+  s.add_dependency "rails", ">= 3.2.7", "<= 4"
   s.add_development_dependency "sqlite3"
 end

--- a/spec/dummy/app/models/product.rb
+++ b/spec/dummy/app/models/product.rb
@@ -1,4 +1,3 @@
 class Product < ActiveRecord::Base
-  attr_accessible :name
   eav_hash_for :tech_specs
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -4,7 +4,7 @@ require File.expand_path('../boot', __FILE__)
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-require "active_resource/railtie"
+# require "active_resource/railtie"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
@@ -48,12 +48,6 @@ module Dummy
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
     # config.active_record.schema_format = :sql
-
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    config.active_record.whitelist_attributes = true
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -6,9 +6,6 @@ Dummy::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -22,9 +19,6 @@ Dummy::Application.configure do
   # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   config.active_record.auto_explain_threshold_in_seconds = 0.5
@@ -34,4 +28,7 @@ Dummy::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  # Introduced in Rails 4
+  config.eager_load = false
 end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -64,4 +64,7 @@ Dummy::Application.configure do
   # Log the query plan for queries taking more than this (works
   # with SQLite, MySQL, and PostgreSQL)
   # config.active_record.auto_explain_threshold_in_seconds = 0.5
+
+  # Introduced in Rails 4
+  config.eager_load = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -11,9 +11,6 @@ Dummy::Application.configure do
   config.serve_static_assets = true
   config.static_cache_control = "public, max-age=3600"
 
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
@@ -29,9 +26,9 @@ Dummy::Application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :spec
 
-  # Raise exception on mass assignment protection for Active Record models
-  config.active_record.mass_assignment_sanitizer = :strict
-
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
+
+  # Introduced in Rails 4
+  config.eager_load = false
 end

--- a/spec/lib/eav_hashes/eav_hash_spec.rb
+++ b/spec/lib/eav_hashes/eav_hash_spec.rb
@@ -12,127 +12,137 @@ describe "EavHash/EavEntry" do
         p3.save!
 
         p3_pulled = Product.find_by_id(p3_id)
-        p3_pulled.tech_specs.keys.length.should == 0
+#        p3_pulled.tech_specs.keys.length.should == 0
+        expect(p3_pulled.tech_specs.keys.length).to eq(0)
+        
     end
 
     it "is able to search for all models whose hashes contain a specified key" do
-        Product.find_by_tech_specs("A String").length.should be == 2
-        Product.find_by_tech_specs(:only_in_product_2).length.should be == 1
+#        Product.find_by_tech_specs("A String").length.should be == 2
+        expect(Product.find_by_tech_specs("A String").length).to eq(2)
+
+#        Product.find_by_tech_specs(:only_in_product_2).length.should be == 1
+        expect(Product.find_by_tech_specs(:only_in_product_2).length).to eq(1)
     end
 
     describe "distinguishes between string and symbol keys" do
         it "finds a value for symbol key \":symbolic_key\" in Product 1" do
-            p1.tech_specs[:symbolic_key].should_not be_nil
+#            p1.tech_specs[:symbolic_key].should_not be_nil
+            expect(p1.tech_specs[:symbolic_key]).not_to be_nil
         end
 
         it "does not find a value for non-symbol key \"symbolic_key\" in Product 1" do
-            p1.tech_specs["symbolic_key"].should be_nil
+#            p1.tech_specs["symbolic_key"].should be_nil
+            expect(p1.tech_specs["symbolic_key"]).to be_nil
         end
     end
 
     describe "preserves types between serialization and deserialization" do
         it "preserves String value types" do
-            p1.tech_specs["A String"].should be_a_kind_of String
+#            p1.tech_specs["A String"].should be_a_kind_of String
+            expect(p1.tech_specs["A String"]).to be_a_kind_of String
         end
 
         it "preserves Symbol value types" do
-            p1.tech_specs["A Symbol"].should be_a_kind_of Symbol
+#            p1.tech_specs["A Symbol"].should be_a_kind_of Symbol
+            expect(p1.tech_specs["A Symbol"]).to be_a_kind_of Symbol
         end
 
         it "preserves Integer/Bignum/Fixnum value types" do
-            p1.tech_specs["A Number"].should be_a_kind_of Integer
+#            p1.tech_specs["A Number"].should be_a_kind_of Integer
+            expect(p1.tech_specs["A Number"]).to be_a_kind_of Integer
         end
 
         it "preserves Symbol value types" do
-            p1.tech_specs["A Float"].should be_a_kind_of Float
+            expect(p1.tech_specs["A Float"]).to be_a_kind_of Float
         end
 
         it "preserves Complex value types" do
-            p1.tech_specs["A Complex"].should be_a_kind_of Complex
+            expect(p1.tech_specs["A Complex"]).to be_a_kind_of Complex
         end
 
         it "preserves Rational value types" do
-            p1.tech_specs["A Rational"].should be_a_kind_of Rational
+            expect(p1.tech_specs["A Rational"]).to be_a_kind_of Rational
         end
 
         it "preserves Boolean(true) value types" do
-            p1.tech_specs["True"].should be_a_kind_of TrueClass
+            expect(p1.tech_specs["True"]).to be_a_kind_of TrueClass
         end
 
         it "preserves Boolean(false) value types" do
-            p1.tech_specs["False"].should be_a_kind_of FalseClass
+            expect(p1.tech_specs["False"]).to be_a_kind_of FalseClass
         end
 
         it "preserves Array value types" do
-            p1.tech_specs["An Array"].should be_a_kind_of Array
+            expect(p1.tech_specs["An Array"]).to be_a_kind_of Array
         end
 
         it "preserves Hash value types" do
-            p1.tech_specs["A Hash"].should be_a_kind_of Hash
+            expect(p1.tech_specs["A Hash"]).to be_a_kind_of Hash
         end
 
         it "preserves user-defined value types" do
-            p1.tech_specs["An Object"].should be_a_kind_of CustomTestObject
+            expect(p1.tech_specs["An Object"]).to be_a_kind_of CustomTestObject
         end
     end
 
     describe "preserves values between serialization and deserialization" do
         it "preserves String values" do
-            p1.tech_specs["A String"].should be == "Strings are for cats!"
+            expect(p1.tech_specs["A String"]).to eq("Strings are for cats!")
         end
 
         it "preserves Symbols" do
-            p1.tech_specs["A Symbol"].should be == :symbol
+            expect(p1.tech_specs["A Symbol"]).to eq(:symbol)
         end
 
         it "preserves Integer/Bignum/Fixnum value types" do
-            p1.tech_specs["A Number"].should be == 42
+            expect(p1.tech_specs["A Number"]).to eq(42)
         end
 
         it "preserves Symbol values" do
-            p1.tech_specs["A Float"].should be == 3.141592653589793
+            expect(p1.tech_specs["A Float"]).to eq(3.141592653589793)
         end
 
         it "preserves Complex values" do
-            p1.tech_specs["A Complex"].should be == Complex("3.141592653589793+42i")
+            expect(p1.tech_specs["A Complex"]).to eq(Complex("3.141592653589793+42i"))
         end
 
         it "preserves Rational values" do
-            p1.tech_specs["A Rational"].should be == Rational(Math::PI)
+            expect(p1.tech_specs["A Rational"]).to eq(Rational(Math::PI))
         end
 
         it "preserves Boolean(true) values" do
-            p1.tech_specs["True"].should be == true
+            expect(p1.tech_specs["True"]).to eq(true)
         end
 
         it "preserves Boolean(false) values" do
-            p1.tech_specs["False"].should be == false
+            expect(p1.tech_specs["False"]).to eq(false)
         end
 
         it "preserves Array values" do
-            p1.tech_specs["An Array"].should be == ["blue", 42, :flux_capacitor]
+            expect(p1.tech_specs["An Array"]).to eq(["blue", 42, :flux_capacitor])
         end
 
         it "preserves Hash values" do
-            p1.tech_specs["A Hash"].should be == {:foo => :bar}
+            expect(p1.tech_specs["A Hash"]).to eq({:foo => :bar})
         end
 
         it "preserves user-defined values" do
-            p1.tech_specs["An Object"].test_value.should be == 42
+            expect(p1.tech_specs["An Object"].test_value).to eq(42)
         end
     end
 
     describe "cannot search by arrays, hashes, and objects" do
         it "raises an error when searched by an object" do
-            lambda { Product.find_by_tech_specs("An Object", CustomTestObject.new(42)) }.should raise_error()
+            expect(lambda { Product.find_by_tech_specs("An Object", CustomTestObject.new(42)) }).to raise_error()
         end
 
         it "raises an error when searched by a hash" do
-            lambda { Product.find_by_tech_specs("A Hash", {:foo => :bar}) }.should raise_error()
+            expect(lambda { Product.find_by_tech_specs("A Hash", {:foo => :bar}) }).to raise_error()
         end
 
         it "raises an error when searched by an array" do
-            lambda { Product.find_by_tech_specs("An Array", ["blue", 42, :flux_capacitor]) }.should raise_error()
+            expect(lambda { Product.find_by_tech_specs("An Array", ["blue", 42, :flux_capacitor]) }).to raise_error()
         end
     end
 end

--- a/spec/lib/generators/eav_migration_spec.rb
+++ b/spec/lib/generators/eav_migration_spec.rb
@@ -8,19 +8,19 @@ describe EavMigrationGenerator do
   describe "#model_association_name" do
     context "when the model is at the top level" do
       it "should underscore the model name" do
-        top_level_model_generator.model_association_name.should == "test_model"
+        expect(top_level_model_generator.model_association_name).to eq ("test_model")
       end
     end
 
     context "when the model is namespaced by one module" do
       it "should underscore the model name, replacing the slash with an underscore" do
-        one_module_generator.model_association_name.should == "foo_test_model"
+        expect(one_module_generator.model_association_name).to eq ("foo_test_model")
       end
     end
 
     context "when the model is namespaced by multiple modules" do
       it "should underscore the model name, replacing the slashes with underscores" do
-        multi_module_generator.model_association_name.should == "foo_bar_test_model"
+        expect(multi_module_generator.model_association_name).to eq ("foo_bar_test_model")
       end
     end
   end
@@ -28,19 +28,19 @@ describe EavMigrationGenerator do
   describe "#table_name" do
     context "when the model is at the top level" do
       it "should underscore the model name and append the hash name" do
-        top_level_model_generator.table_name.should == "test_model_test_hash"
+        expect(top_level_model_generator.table_name).to eq ("test_model_test_hash")
       end
     end
 
     context "when the model is namespaced by one module" do
       it "should underscore the model name, replacing the slash with an underscore, and append the hash name" do
-        one_module_generator.table_name.should == "foo_test_model_test_hash"
+        expect(one_module_generator.table_name).to eq ("foo_test_model_test_hash")
       end
     end
 
     context "when the model is namespaced by multiple modules" do
       it "should underscore the model name, replacing the slashes with underscores, and append the hash name" do
-        multi_module_generator.table_name.should == "foo_bar_test_model_test_hash"
+        expect(multi_module_generator.table_name).to eq ("foo_bar_test_model_test_hash")
       end
     end
   end
@@ -48,13 +48,13 @@ describe EavMigrationGenerator do
   describe "#migration_file_name" do
     context "when the model is at the top level" do
       it "should return create_ followed by the table name" do
-        top_level_model_generator.migration_file_name.should == "create_test_model_test_hash"
+        expect(top_level_model_generator.migration_file_name).to eq ("create_test_model_test_hash")
       end
     end
 
     context "when the model is namespaced by one or more modules" do
       it "should return create_ followed by the table name, with module names included" do
-        multi_module_generator.migration_file_name.should == "create_foo_bar_test_model_test_hash"
+        expect(multi_module_generator.migration_file_name).to eq ("create_foo_bar_test_model_test_hash")
       end
     end
   end


### PR DESCRIPTION
As per https://github.com/iostat/eav_hashes/issues/4, ActiveRecord has not changed that much, so porting to support Rails4 was more about cosmetic changes than anything else. A summary of changes:

* Modified gemspec to support rails 3.2.7+
* Removed rails 3.x deprecated configuration variables and replaced with newly introduced 4.x
* Modified rspec tests from deprecated 'should' to 'expect' syntax
* Removed ActiveResource references, removed from Rails4 core
* Removed attribute whitelisting, as with strong_parameters this is now taken care of in the controllers

RSpec runs cleanly with no deprecation warnings and the gem has been tested with a sample Rails4 application successfully.