### PR TITLE
Fixes each

### DIFF
--- a/lib/eav_hashes/eav_hash.rb
+++ b/lib/eav_hashes/eav_hash.rb
@@ -87,7 +87,7 @@ module ActiveRecord
 
       # Emulates Hash.each
       def each (&block)
-        as_hash.each block
+        as_hash.each &block
       end
 
       # Emulates Hash.each_pair (same as each)

--- a/spec/lib/eav_hashes/eav_hash_spec.rb
+++ b/spec/lib/eav_hashes/eav_hash_spec.rb
@@ -145,4 +145,10 @@ describe "EavHash/EavEntry" do
             expect(lambda { Product.find_by_tech_specs("An Array", ["blue", 42, :flux_capacitor]) }).to raise_error()
         end
     end
+    
+    describe "enumerable" do
+        it "each gives an enumerator" do
+            expect(p1.tech_specs.each).to be_instance_of(Enumerator)
+        end
+    end
 end


### PR DESCRIPTION
When I tried to use the each method it gave me `ArgumentError: wrong number of arguments (given 1, expected 0)` error. With the changes here the each and each_pair methods are usable.