### PR TITLE
Issue #7: Fixing deprecation warning in Rails 5.1

### DIFF
--- a/lib/eav_hashes/activerecord_extension.rb
+++ b/lib/eav_hashes/activerecord_extension.rb
@@ -17,7 +17,7 @@ module ActiveRecord
 
         # Create the association, the entry update hook, and a helper method to lazy-load the entries
         class_eval <<-END_EVAL
-          has_many :#{options[:entry_assoc_name]}, class_name: #{options[:entry_class_name]}, foreign_key: "#{options[:parent_assoc_name]}_id", dependent: :delete_all
+          has_many :#{options[:entry_assoc_name]}, class_name: "#{options[:entry_class_name]}", foreign_key: "#{options[:parent_assoc_name]}_id", dependent: :delete_all
           after_save :save_#{hash_name}
           def #{hash_name}
             @#{hash_name} ||= ActiveRecord::EavHashes::EavHash.new(self, @@#{hash_name}_hash_options)


### PR DESCRIPTION
Simple fix for https://github.com/iostat/eav_hashes/issues/7.