### PR TITLE
Register value changes on updates

### DIFF
--- a/lib/eav_hashes/eav_entry.rb
+++ b/lib/eav_hashes/eav_entry.rb
@@ -49,7 +49,8 @@ module ActiveRecord
       # Sets the EAV row's value
       # @param [Object] val the value
       def value= (val)
-        value_will_change!
+        both_nil = (@value.nil? || @value.is_a?(ActiveRecord::EavHashes::NilPlaceholder)) && (val.nil? || val.is_a?(ActiveRecord::EavHashes::NilPlaceholder))
+        value_will_change! if @value != val && !both_nil
         @value = (val.nil? ? NilPlaceholder.new : val)
       end
 

--- a/lib/eav_hashes/eav_entry.rb
+++ b/lib/eav_hashes/eav_entry.rb
@@ -49,6 +49,7 @@ module ActiveRecord
       # Sets the EAV row's value
       # @param [Object] val the value
       def value= (val)
+        value_will_change!
         @value = (val.nil? ? NilPlaceholder.new : val)
       end
 


### PR DESCRIPTION
Because we are not updating the attribute right away, ActiveRecord doesn't
know the value has changed, and thus `entry.changes` is empty. Let's notify
the value change and be able to rely on changes notificacions.