### PR TITLE
Compatibility with Ruby 3.1

### DIFF
--- a/lib/eav_hashes/eav_entry.rb
+++ b/lib/eav_hashes/eav_entry.rb
@@ -107,7 +107,7 @@ module ActiveRecord
 
         case value_type
           when SUPPORTED_TYPES[:Object] # or Hash, Array, etc.
-            @value = YAML::load @value
+            load_yaml_value
           when SUPPORTED_TYPES[:Symbol]
             @value = @value.to_sym
           when SUPPORTED_TYPES[:Integer] # or Fixnum, Bignum
@@ -122,6 +122,16 @@ module ActiveRecord
             @value = (@value == "true")
           else
             @value
+        end
+      end
+
+      if Gem::Version.new(YAML::VERSION) >= Gem::Version.new("4.0")
+        def load_yaml_value
+          @value = YAML::unsafe_load @value
+        end
+      else
+        def load_yaml_value
+          @value = YAML::load @value
         end
       end
     end


### PR DESCRIPTION
With Ruby 3.1 psych version gets bumped to 4.x, which changes the behavior of `YAML.load` to `YAML.safe_load`. Since this YAML content is controlled by this gem, we can assume it's safe to keep the old default behavior of `unsafe_load`.

Since old psych versions don't implement `unsafe_load`, we need to dynamically evaluate which method to use at load time.